### PR TITLE
Update the NL list of cities to all 353 communities

### DIFF
--- a/pak128.prototype/text/citylist_nl.txt
+++ b/pak128.prototype/text/citylist_nl.txt
@@ -1,172 +1,353 @@
-Aalsmeer
-Aalst
-Abcoude
-Alkmaar
-Almelo
-Alphen aan den Rijn
-Amersfoort
-Amstelveen
-Amsterdam
-Apeldoorn
-Appelscha
-Arnhem
-Assen
-Baarn
-Barendrecht
-Bergen op Zoom
-Beverwijk
-Biddinghuizen
-Bilthoven
-Bodegraven
-Borssele
-Boxmeer
-Breda
-Breskens
-Capelle aan den IJssel
-Castricum
-Culemborg
-De Bilt
-Dedemsvaart
-Delft
-Delfzijl
-Den Bosch
-Den Haag
-Den Helder
-Deventer
-Dodewaard
-Doetinchem
-Dokkum
-Dordrecht
-Dronten
-Duivendrecht
-Edam
-Ede
-Eindhoven
-Emmeloord
-Emmen
-Enschede
-Franeker
-Geldermalsen
-Geleen
-Goes
-Goirle
-Gorinchem
-Gorredijk
-Gouda
-Groningen
-Haarlem
-Harderwijk
-Harlingen
+Aa en Hunze 
+Aalsmeer 
+Aalten 
+Achtkarspelen 
+Alblasserdam 
+Albrandswaard 
+Alkmaar 
+Almelo 
+Almere 
+Alphen aan den Rijn 
+Alphen-Chaam 
+Altena 
+Ameland 
+Amersfoort 
+Amstelveen 
+Amsterdam 
+Apeldoorn 
+Arnhem 
+Assen 
+Asten 
+Baarle-Nassau 
+Baarn 
+Barendrecht 
+Barneveld 
+Beek 
+Beekdaelen 
+Beesel 
+Berg en Dal 
+Bergeijk 
+Bergen, Limburg 
+Bergen, Noord-Holland 
+Bergen op Zoom 
+Berkelland 
+Bernheze 
+Best 
+Beuningen 
+Beverwijk 
+Bladel 
+Blaricum 
+Bloemendaal 
+Bodegraven-Reeuwijk 
+Boekel 
+Bonaire 
+Borger-Odoorn 
+Borne 
+Borsele 
+Boxmeer 
+Boxtel 
+Breda 
+Brielle 
+Bronckhorst 
+Brummen 
+Brunssum 
+Bunnik 
+Bunschoten 
+Buren 
+Capelle aan den IJssel 
+Castricum 
+Coevorden 
+Cranendonck 
+Cuijk 
+Culemborg 
+Dalfsen 
+Dantumadeel
+De Bilt 
+De Friese Meren
+De Ronde Venen 
+De Wolden 
+Delft 
+Den Helder 
+Deurne 
+Deventer 
+Diemen 
+Dinkelland 
+Doesburg 
+Doetinchem 
+Dongen 
+Dordrecht 
+Drechterland 
+Drimmelen 
+Dronten 
+Druten 
+Duiven 
+Echt-Susteren 
+Edam-Volendam 
+Ede 
+Eemnes 
+Eemsdelta 
+Eersel 
+Eijsden-Margraten 
+Eindhoven 
+Elburg 
+Emmen 
+Enkhuizen 
+Enschede 
+Epe 
+Ermelo 
+Etten-Leur 
+Geertruidenberg 
+Geldrop-Mierlo 
+Gemert-Bakel 
+Gennep 
+Gilze en Rijen 
+Goeree-Overflakkee 
+Goes 
+Goirle 
+Gooise Meren 
+Gorinchem 
+Gouda 
+Grave 
+Groningen 
+Gulpen-Wittem 
+Haaksbergen 
+Haarlem 
+Haarlemmermeer 
+Halderberge 
+Hardenberg 
+Harderwijk 
+Hardinxveld-Giessendam 
+Harlingen 
+Hattem 
+Heemskerk 
+Heemstede 
+Heerde
 Heerenveen
+Heerhugowaard
+Heerlen
+Heeze-Leende
+Heiloo
 Hellendoorn
 Hellevoetsluis
 Helmond
+Hendrik-Ido-Ambacht
 Hengelo
+'s-Hertogenbosch
+Het Hogeland
+Heumen
+Heusden
 Hillegom
+Hilvarenbeek
 Hilversum
-Hoek van Holland
-Hoenderloo
-Hoofddorp
+Hoeksche Waard
+Hof van Twente
+Hollands Kroon
 Hoogeveen
 Hoorn
+Horst aan de Maas
+Houten
 Huizen
-IJmuiden
-Joure
-Kaatsheuvel
+Hulst
+IJsselstein
+Kaag en Braassem
+Kampen
+Kapelle
 Katwijk
-Kockengen
-Kruiningen
+Kerkrade
+Koggenland
+Krimpen aan den IJssel
+Krimpenerwaard
+Laarbeek
+Landerd
+Landgraaf
+Landsmeer
+Langedijk
+Lansingerland
 Laren
-Leerdam
 Leeuwarden
 Leiden
 Leiderdorp
-Leidschendam
+Leidschendam-Voorburg
 Lelystad
+Leudal
 Leusden
-Lichtenvoorde
+Lingewaard
 Lisse
 Lochem
+Loon op Zand
 Lopik
-Maarssen
+Losser
+Maasdriel
+Maasgouw
 Maassluis
 Maastricht
-Marken
-Mechelen
+Medemblik
+Meerssen
+Meierijstad
 Meppel
 Middelburg
-Moerkapelle
-Monnickendam
-Monster
-Muiden
-Naaldwijk
-Naarden
-Nieuw-Vennep
+Midden-Delfland
+Midden-Drenthe
+Midden-Groningen
+Mill en Sint Hubert
+Moerdijk
+Molenlanden
+Montferland
+Montfoort
+Mook en Middelaar
+Neder-Betuwe
+Nederweert
+Nieuwegein
+Nieuwkoop
 Nijkerk
 Nijmegen
+Nissewaard
+Noardeast-Fryslân
+Noord-Beveland
+Noordenveld
+Noordoostpolder
 Noordwijk
-Nootdorp
-Nuenen
+Nuenen, Gerwen en Nederwetten
+Nunspeet
+Oegstgeest
 Oirschot
+Oisterwijk
+Oldambt
+Oldebroek
 Oldenzaal
+Olst-Wijhe
 Ommen
+Oost Gelre
+Oosterhout
+Ooststellingwerf
+Oostzaan
+Opmeer
+Opsterland
 Oss
-Petten
+Oude IJsselstreek
+Ouder-Amstel
+Oudewater
+Overbetuwe
+Papendrecht
+Peel en Maas
+Pekela
+Pijnacker-Nootdorp
+Purmerend
 Putten
+Raalte
+Reimerswaal
+Renkum
 Renswoude
+Reusel-De Mierden
+Rheden
 Rhenen
 Ridderkerk
+Rijssen-Holten
 Rijswijk
+Roerdalen
 Roermond
 Roosendaal
 Rotterdam
-s-Hertogenbosch
-Sassenheim
+Rozendaal
+Rucphen
+Saba
+Schagen
+Scherpenzeel
 Schiedam
-Sittard
-Slochteren
-Sneek
+Schiermonnikoog
+Schouwen-Duiveland
+Simpelveld
+Sint Eustatius
+Sint Anthonis
+Sint-Michielsgestel
+Sittard-Geleen
+Sliedrecht
+Sluis
+Smallingerland
 Soest
-Spaarnwoude
-Spijkenisse
+Someren
+Son en Breugel
 Stadskanaal
+Staphorst
+Stede Broec
+Steenbergen
+Steenwijkerland
+Stein
+Stichtse Vecht
+Súdwest-Fryslân
 Terneuzen
+Terschelling
+Texel
+Teylingen
+The Hague
 Tholen
 Tiel
 Tilburg
+Tubbergen
+Twenterand
+Tynaarlo
+Tytsjerksteradiel
+Uden
 Uitgeest
+Uithoorn
 Urk
 Utrecht
-Valkenburg
+Utrechtse Heuvelrug
+Vaals
+Valkenburg aan de Geul
+Valkenswaard
+Veendam
 Veenendaal
+Veere
+Veldhoven
+Velsen
 Venlo
 Venray
-Vianen
+Vijfheerenlanden
 Vlaardingen
+Vlieland
 Vlissingen
-Volendam
+Voerendaal
+Voorschoten
+Voorst
 Vught
+Waadhoeke
+Waalre
 Waalwijk
 Waddinxveen
 Wageningen
-Warmond
 Wassenaar
+Waterland
 Weert
-Westerbork
-Westkapelle
+Weesp
+West Betuwe
+West Maas en Waal
+Westerkwartier
+Westerveld
+Westervoort
+Westerwolde
+Westland
+Weststellingwerf
+Westvoorne
+Wierden
+Wijchen
+Wijdemeren
 Wijk bij Duurstede
 Winterswijk
+Woensdrecht
 Woerden
-Yerseke
-Ysselsteyn
-Zaandam
+Wormerland
+Woudenberg
 Zaanstad
 Zaltbommel
 Zandvoort
 Zeewolde
 Zeist
-Zevenbergen
+Zevenaar
 Zoetermeer
-Zwammerdam
+Zoeterwoude
+Zuidplas
+Zundert
+Zutphen
+Zwartewaterland
 Zwijndrecht
-Zwolle


### PR DESCRIPTION
Update the Dutch list of cities to a complete list of all 353 official communities in the Netherlands.