### PR TITLE
Change Github actions so the Nightly release is re-created instead of edited.

### DIFF
--- a/.github/workflows/pak128-nightly.yml
+++ b/.github/workflows/pak128-nightly.yml
@@ -42,11 +42,9 @@ jobs:
         mv simupak128.zip simupak128-nightly.zip
 
     - name: Update Serverset of Nightly Release
-      uses: svenstaro/upload-release-action@v1-release
-      with:
-        repo_token: ${{ secrets.GITHUB_TOKEN }}
-        file: ./simupak128-nightly.zip
-        asset_name: simupak128-nightly.zip
-        tag: Nightly
-        overwrite: true
+      run: |
+        git push origin --delete Nightly || true
+        gh release create Nightly simupak128-nightly.zip --generate-notes --title "Nightly $(date -u +%Y-%m-%d)"
+      env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
  

--- a/.github/workflows/pak128-nightly.yml
+++ b/.github/workflows/pak128-nightly.yml
@@ -44,7 +44,7 @@ jobs:
     - name: Update Serverset of Nightly Release
       run: |
         git push origin --delete Nightly || true
-        gh release create Nightly simupak128-nightly.zip --generate-notes --title "Nightly $(date -u +%Y-%m-%d)"
+        gh release create Nightly simupak128-nightly.zip --generate-notes --title "Nightly $(date -u +%Y-%m-%d)" --target "master"
       env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
  


### PR DESCRIPTION
As exemplified by #16, the current method is a bit confusing, as it does not update the date, body and referenced commit of the release.

This method follows another approach - it deletes the current release (by deleting the Nightly tag), then re-creates it, thus referencing the latest commit. It also uses the gh cli tool instead of an external action. I added the date to the release title for even more clarity, but that's not necessary.

Drawbacks: If you are following releases, you will be notified a new release has been done.

What do you think about it?